### PR TITLE
security: clamp solver iterations + add HTTP security headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,12 @@
 /** @type {import('next').NextConfig} */
+const securityHeaders = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  { key: "X-XSS-Protection", value: "1; mode=block" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["three"],
@@ -7,6 +15,9 @@ const nextConfig = {
   webpack: (config) => {
     config.externals = [...(config.externals || []), { canvas: "canvas" }];
     return config;
+  },
+  async headers() {
+    return [{ source: "/(.*)", headers: securityHeaders }];
   },
 };
 

--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -228,6 +228,8 @@ export async function POST(request: NextRequest) {
 
     const nx = Math.max(10, Math.min(100, Math.round(Math.sqrt(meshElements))));
     const ny = nx;
+    const maxIter = Math.max(1, Math.min(500, Math.round(solverConfig.maxIterations)));
+    const tolerance = Math.max(1e-10, Math.min(1, solverConfig.tolerance));
     const width = geometry?.width || 100;
     const height = geometry?.height || 50;
     const E = parseFloat(material.E) || 205e9;
@@ -239,7 +241,7 @@ export async function POST(request: NextRequest) {
 
     switch (analysisType) {
       case "thermal": {
-        const thermal = solveThermal2D(nx, ny, k, 400, 300, 350, 320, solverConfig.maxIterations, solverConfig.tolerance);
+        const thermal = solveThermal2D(nx, ny, k, 400, 300, 350, 320, maxIter, tolerance);
         const tMin = Math.min(...thermal.field);
         const tMax = Math.max(...thermal.field);
         const tAvg = thermal.field.reduce((s, v) => s + v, 0) / thermal.field.length;
@@ -273,7 +275,7 @@ export async function POST(request: NextRequest) {
         const inletV = cfdConfig?.inletVelocity || 10;
         const rho = parseFloat(material.rho) || 1.225;
         const mu = 1.81e-5;
-        const cfd = solveCFD2D(nx, ny, inletV, rho, mu, solverConfig.maxIterations);
+        const cfd = solveCFD2D(nx, ny, inletV, rho, mu, maxIter);
 
         results = {
           velocity: { max: Math.round(cfd.maxVel * 100) / 100, min: 0, avg: Math.round(cfd.maxVel * 0.67 * 100) / 100, unit: "m/s" },
@@ -327,7 +329,7 @@ export async function POST(request: NextRequest) {
       success: true,
       jobId: crypto.randomUUID(),
       status: "converged",
-      iterations: solverConfig.maxIterations,
+      iterations: maxIter,
       wallTime: `${wallTime}s`,
       meshInfo: { elements: meshElements, nodes: Math.round(meshElements * 0.18) },
       material: material.name,


### PR DESCRIPTION
## Summary (Saturday Security Angle)

Two targeted security fixes from the weekly dead-code + security audit.

### 1. DoS fix — `/api/simulate` unbounded solver loop

`solverConfig.maxIterations` was passed directly from the request body into the inner solver loops with no upper bound. A caller could send `maxIterations: 10_000_000` and pin the serverless function at 100% CPU until timeout, potentially racking up compute cost or starving real users.

**Fix:** clamp at request boundary before any solver call:
```ts
const maxIter  = Math.max(1,    Math.min(500,  Math.round(solverConfig.maxIterations)));
const tolerance = Math.max(1e-10, Math.min(1,  solverConfig.tolerance));
```
500 iterations is well above convergence for the current grid sizes (10–100 cells).

### 2. Missing HTTP security headers — `next.config.mjs`

The app shipped with zero security response headers. Added via Next.js `headers()` hook:

| Header | Value |
|--------|-------|
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `SAMEORIGIN` |
| `X-XSS-Protection` | `1; mode=block` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |

## Test plan

- [ ] POST `/api/simulate` with `maxIterations: 9999999` → response returns quickly with `iterations ≤ 500`
- [ ] curl any page, verify security headers present in response
- [ ] Existing simulate UI still works end-to-end for thermal / CFD / structural

## Related issues filed (risky cleanups — not in this PR)

- #TBD — Remove orphaned `src/lib/drawing-engine.ts` (757 lines, zero imports)
- #TBD — Remove unused `AIChatAssistant.tsx` (superseded by Enhanced variant)
- #TBD — Prune unused dependencies: `react-icons`, `three-bvh-csg`, `framer-motion`, `html2canvas`

https://claude.ai/code/session_01MbXnQXnnNnZhjHKAehEhLq

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbXnQXnnNnZhjHKAehEhLq)_