### PR TITLE
security: harden API routes and SVG rendering (Sat audit)

### DIFF
--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -187,6 +187,15 @@ function parseDimensions(prompt: string): ParsedDimensions {
     if (genericMm) dims.width = parseWithUnit(genericMm) ?? undefined;
   }
 
+  // Clamp all parsed dimensions to safe fabrication bounds (0.1 mm … 10 000 mm)
+  const CLAMP_MIN = 0.1, CLAMP_MAX = 10_000;
+  for (const key of Object.keys(dims) as (keyof ParsedDimensions)[]) {
+    const v = dims[key];
+    if (typeof v === "number") {
+      (dims as Record<string, number>)[key] = Math.min(Math.max(v, CLAMP_MIN), CLAMP_MAX);
+    }
+  }
+
   return dims;
 }
 
@@ -677,6 +686,12 @@ export async function POST(request: NextRequest) {
     if ((!prompt || prompt.trim().length === 0) && (!messages || messages.length === 0)) {
       return NextResponse.json({ error: "Prompt or messages array is required" }, { status: 400 });
     }
+    if (prompt && prompt.length > 10_000) {
+      return NextResponse.json({ error: "Prompt exceeds maximum length of 10 000 characters" }, { status: 400 });
+    }
+    if (imageBase64 && imageBase64.length > 5_000_000) {
+      return NextResponse.json({ error: "Image payload exceeds 5 MB limit" }, { status: 400 });
+    }
 
     const activePrompt = prompt || messages?.[messages.length - 1]?.content || "";
     const currentConversationId = conversationId || randomUUID();
@@ -802,8 +817,9 @@ export async function POST(request: NextRequest) {
       fallback: !apiKey,
     } as GenerateResponse);
   } catch (error) {
+    console.error("[ai/generate] unhandled error:", error);
     return NextResponse.json(
-      { error: "Failed to generate", details: String(error) },
+      { error: "Failed to generate" },
       { status: 500 }
     );
   }

--- a/src/app/api/generate-cad/route.ts
+++ b/src/app/api/generate-cad/route.ts
@@ -745,6 +745,9 @@ export async function POST(request: NextRequest) {
     if (!prompt || prompt.trim().length === 0) {
       return NextResponse.json({ error: "Prompt is required" }, { status: 400 });
     }
+    if (prompt.length > 10_000) {
+      return NextResponse.json({ error: "Prompt exceeds maximum length of 10 000 characters" }, { status: 400 });
+    }
 
     // ── Try Claude API for AI-powered geometry generation ──
     const anthropicKey = process.env.ANTHROPIC_API_KEY;
@@ -827,8 +830,9 @@ All dimensions in mm. Return ONLY valid JSON, no markdown.`,
       },
     });
   } catch (error) {
+    console.error("[generate-cad] unhandled error:", error);
     return NextResponse.json(
-      { error: "Failed to generate CAD model", details: String(error) },
+      { error: "Failed to generate CAD model" },
       { status: 500 }
     );
   }

--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -336,8 +336,9 @@ export async function POST(request: NextRequest) {
       engine: analysisType === "cfd" ? "ShilpaSutra CFD v2.0" : "ShilpaSutra FEA v2.0",
     });
   } catch (error) {
+    console.error("[simulate] unhandled error:", error);
     return NextResponse.json(
-      { error: "Simulation failed", details: String(error) },
+      { error: "Simulation failed" },
       { status: 500 }
     );
   }

--- a/src/components/drawings/DrawingCanvas.tsx
+++ b/src/components/drawings/DrawingCanvas.tsx
@@ -6,7 +6,7 @@
 
 import { useRef, useState, useCallback, useEffect } from "react";
 import type { Drawing, Viewport } from "@/lib/drawingEngine";
-import { renderDrawingToSVG, renderDrawingToCanvas, createA3Viewport } from "@/lib/drawingEngine";
+import { renderDrawingToSVG, renderDrawingToCanvas, createA3Viewport, sanitizeSvg } from "@/lib/drawingEngine";
 
 // ── Props ───────────────────────────────────────────────────────────────────
 
@@ -158,7 +158,7 @@ export default function DrawingCanvas({
         {mode === "svg" ? (
           <div
             className="w-full h-full flex items-center justify-center"
-            dangerouslySetInnerHTML={{ __html: svgString.replace(/^<\?xml[^?]*\?>\s*/, '') }}
+            dangerouslySetInnerHTML={{ __html: sanitizeSvg(svgString.replace(/^<\?xml[^?]*\?>\s*/, '')) }}
           />
         ) : (
           <canvas ref={canvasRef} className="w-full h-full" />

--- a/src/components/drawings/IECDrawingSheet.tsx
+++ b/src/components/drawings/IECDrawingSheet.tsx
@@ -7,7 +7,7 @@
 
 import type { IECDrawingData, DrawingView, DrawingShape } from "@/lib/iecDrawingData";
 import { iecToDrawing } from "@/lib/iecDrawingAdapter";
-import { renderDrawingToSVG, createA3Viewport } from "@/lib/drawingEngine";
+import { renderDrawingToSVG, createA3Viewport, sanitizeSvg } from "@/lib/drawingEngine";
 
 // ── SVG sheet constants (A3 landscape in SVG units ≈ mm) ─────────────────────
 const W = 841, H = 594;
@@ -171,7 +171,7 @@ export default function IECDrawingSheet({ data, useEngine = false }: IECDrawingS
   if (useEngine) {
     const unifiedDrawing = iecToDrawing(data);
     const svgString = renderDrawingToSVG(unifiedDrawing, createA3Viewport());
-    const cleanSvg = svgString.replace(/^<\?xml[^?]*\?>\s*/, '');
+    const cleanSvg = sanitizeSvg(svgString.replace(/^<\?xml[^?]*\?>\s*/, ''));
     return (
       <div className="w-full h-full" style={{ background: "white" }}
         dangerouslySetInnerHTML={{ __html: cleanSvg }} />

--- a/src/lib/drawingEngine.ts
+++ b/src/lib/drawingEngine.ts
@@ -476,3 +476,11 @@ function textAnchorMap(align: TextAlign | undefined): string {
 function escapeXml(str: string): string {
   return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
+
+/** Strip script tags, event-handler attributes, and javascript: URIs from SVG strings. */
+export function sanitizeSvg(svg: string): string {
+  return svg
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/\son\w+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi, '')
+    .replace(/(href|src|xlink:href)\s*=\s*["']?\s*javascript:[^"'\s>]*/gi, '$1="about:blank"');
+}


### PR DESCRIPTION
## Summary

Saturday security audit — four targeted hardening fixes across 6 files.

- **Stack-trace disclosure** stripped from all three API route 500 responses; errors now logged server-side only (`console.error`)
- **Request-size DoS guard** added to `/api/ai/generate` (prompt ≤ 10 000 chars, base64 image ≤ 5 MB) and `/api/generate-cad` (prompt ≤ 10 000 chars)
- **Dimension bounds clamping** in `parseDimensions()` clamps every parsed value to [0.1 mm, 10 000 mm] so a prompt like "999999999 m cube" can't exhaust Three.js geometry allocation
- **SVG sanitisation** — new `sanitizeSvg()` export in `drawingEngine.ts` strips `<script>` tags, `on*` event-handler attributes, and `javascript:` URIs; applied in `DrawingCanvas` and `IECDrawingSheet` before `dangerouslySetInnerHTML`

## Files changed

| File | Change |
|---|---|
| `src/lib/drawingEngine.ts` | +`sanitizeSvg()` export |
| `src/components/drawings/DrawingCanvas.tsx` | apply `sanitizeSvg()` before injection |
| `src/components/drawings/IECDrawingSheet.tsx` | apply `sanitizeSvg()` before injection |
| `src/app/api/simulate/route.ts` | remove `details: String(error)` |
| `src/app/api/ai/generate/route.ts` | remove `details`, add prompt/image size guards, add dimension clamping |
| `src/app/api/generate-cad/route.ts` | remove `details`, add prompt size guard |

## Deferred (filed as issues)

- API authentication / JWT middleware — see issue filed
- Rate limiting — see issue filed
- Content-Security-Policy headers — see issue filed

## Test plan

- [ ] POST `/api/ai/generate` with prompt > 10 000 chars → 400 with clear message
- [ ] POST `/api/ai/generate` with base64 image > 5 MB → 400
- [ ] POST `/api/simulate` with bad material → 500 with no stack trace in body
- [ ] DrawingCanvas SVG mode renders correctly (no regression)
- [ ] IECDrawingSheet engine mode renders correctly (no regression)

https://claude.ai/code/session_01KHYPswXcVfXEzwrQ6rr1Eu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHYPswXcVfXEzwrQ6rr1Eu)_