### PR TITLE
security(sat): strip error leaks, add HTTP headers, clamp solver inputs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,20 @@ const nextConfig = {
     config.externals = [...(config.externals || []), { canvas: "canvas" }];
     return config;
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-XSS-Protection", value: "1; mode=block" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,7 +140,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -746,7 +745,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -770,7 +768,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2908,7 +2905,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
       "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -3033,6 +3029,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3053,6 +3050,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -3134,7 +3132,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3326,7 +3325,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3338,7 +3336,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3370,7 +3367,6 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.169.0.tgz",
       "integrity": "sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
@@ -3462,7 +3458,6 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -4006,7 +4001,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4627,7 +4621,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5341,6 +5334,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5452,7 +5446,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.3.3",
@@ -5750,7 +5745,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5920,7 +5914,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7802,7 +7795,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -8897,7 +8889,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8927,7 +8918,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9227,6 +9217,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10115,7 +10106,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10281,6 +10271,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10296,6 +10287,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10308,7 +10300,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -10400,7 +10393,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10425,7 +10417,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11774,8 +11765,7 @@
       "version": "0.169.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
       "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-bvh-csg": {
       "version": "0.0.16",
@@ -11793,7 +11783,6 @@
       "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
       "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "three": ">= 0.151.0"
       }
@@ -11862,7 +11851,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12247,7 +12235,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -677,6 +677,12 @@ export async function POST(request: NextRequest) {
     if ((!prompt || prompt.trim().length === 0) && (!messages || messages.length === 0)) {
       return NextResponse.json({ error: "Prompt or messages array is required" }, { status: 400 });
     }
+    if (prompt && prompt.length > 8000) {
+      return NextResponse.json({ error: "Prompt exceeds maximum length" }, { status: 400 });
+    }
+    if (imageBase64 && imageBase64.length > 10 * 1024 * 1024) {
+      return NextResponse.json({ error: "Image payload exceeds 10 MB limit" }, { status: 400 });
+    }
 
     const activePrompt = prompt || messages?.[messages.length - 1]?.content || "";
     const currentConversationId = conversationId || randomUUID();
@@ -801,9 +807,9 @@ export async function POST(request: NextRequest) {
       conversationId: currentConversationId,
       fallback: !apiKey,
     } as GenerateResponse);
-  } catch (error) {
+  } catch {
     return NextResponse.json(
-      { error: "Failed to generate", details: String(error) },
+      { error: "Failed to generate" },
       { status: 500 }
     );
   }

--- a/src/app/api/generate-cad/route.ts
+++ b/src/app/api/generate-cad/route.ts
@@ -826,9 +826,9 @@ All dimensions in mm. Return ONLY valid JSON, no markdown.`,
         supportedFormats: ["STEP", "STL", "OBJ", "IGES", "3MF", "GLB", "GLTF", "FBX", "DXF", "PLY"],
       },
     });
-  } catch (error) {
+  } catch {
     return NextResponse.json(
-      { error: "Failed to generate CAD model", details: String(error) },
+      { error: "Failed to generate CAD model" },
       { status: 500 }
     );
   }

--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -226,6 +226,11 @@ export async function POST(request: NextRequest) {
     const body: SimulationRequest = await request.json();
     const { analysisType, meshElements, material, solverConfig, cfdConfig, geometry } = body;
 
+    const ALLOWED_ANALYSES = ["structural", "thermal", "cfd", "modal", "fatigue"] as const;
+    if (!ALLOWED_ANALYSES.includes(analysisType as typeof ALLOWED_ANALYSES[number])) {
+      return NextResponse.json({ error: "Invalid analysisType" }, { status: 400 });
+    }
+
     const nx = Math.max(10, Math.min(100, Math.round(Math.sqrt(meshElements))));
     const ny = nx;
     const width = geometry?.width || 100;
@@ -233,6 +238,8 @@ export async function POST(request: NextRequest) {
     const E = parseFloat(material.E) || 205e9;
     const nu = parseFloat(material.v) || 0.29;
     const k = parseFloat(material.k) || 50;
+    solverConfig.maxIterations = Math.max(1, Math.min(500, Math.round(solverConfig.maxIterations || 100)));
+    solverConfig.tolerance = Math.max(1e-10, Math.min(1, solverConfig.tolerance || 1e-6));
     const startTime = Date.now();
 
     let results: Record<string, unknown>;
@@ -335,9 +342,9 @@ export async function POST(request: NextRequest) {
       results,
       engine: analysisType === "cfd" ? "ShilpaSutra CFD v2.0" : "ShilpaSutra FEA v2.0",
     });
-  } catch (error) {
+  } catch {
     return NextResponse.json(
-      { error: "Simulation failed", details: String(error) },
+      { error: "Simulation failed" },
       { status: 500 }
     );
   }


### PR DESCRIPTION
## Saturday security pass — 4 targeted hardening changes

### Changes

| File | Change |
|------|--------|
| `next.config.mjs` | Add 5 HTTP security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy`) |
| `api/ai/generate/route.ts` | Strip `details: String(error)` from 500 response; add 8 000-char prompt cap + 10 MB image cap |
| `api/generate-cad/route.ts` | Strip `details: String(error)` from 500 response |
| `api/simulate/route.ts` | Strip `details: String(error)` from 500 response; whitelist `analysisType`; clamp `maxIterations` to [1, 500] and `tolerance` to [1e-10, 1] |

### Why

- **Error-detail leakage**: `String(error)` in production 500 responses can expose internal file paths, stack traces, or fragments of upstream API responses (incl. key prefixes). Removed from all three routes.
- **HTTP headers**: `X-Frame-Options: DENY` prevents clickjacking; `nosniff` prevents MIME-sniffing attacks; CSP groundwork.
- **Prompt/image size caps**: Without input size guards the AI routes accept arbitrarily large payloads, burning API credits or exhausting memory.
- **Solver DoS**: Unbounded `maxIterations` in the Gauss-Seidel thermal/CFD/structural loops allows a single request to saturate a serverless CPU for seconds. Clamped to 500.

### Deferred to issues
- API authentication & rate-limiting → see issue filed alongside this PR
- `@anthropic-ai/sdk` bump (GHSA-5474-4w2j-mq4c / GHSA-p7fg-763f-g4gf) → fix requires `--force` breaking change to `0.101.0`, needs review
- Vec3 math duplicates across `constraint-store.ts` / `assembly-engine.ts` / `mate-solver.ts` → refactor issue filed

### Vercel production status
Last production deploy (`dpl_689T4iCMbHXaqjzUfg5G36W3YDYK`) on `main` is ✅ **READY**.

### Test plan
- [ ] TypeScript: `npx tsc --noEmit` — passes ✅
- [ ] Confirm API routes return `{ error: "..." }` only (no `details` key) on error
- [ ] Confirm `/api/simulate` rejects `analysisType: "evil"` with 400
- [ ] Confirm `/api/ai/generate` rejects prompts > 8 000 chars with 400
- [ ] Verify security headers present on deployed URL via curl or browser DevTools

https://claude.ai/code/session_015aqWZP4B4WDEixeZ79XF8q

---
_Generated by [Claude Code](https://claude.ai/code/session_015aqWZP4B4WDEixeZ79XF8q)_