### PR TITLE
enhance(wed): bump stale Claude model IDs in both API routes

### DIFF
--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -746,7 +746,7 @@ export async function POST(request: NextRequest) {
             "X-Title": "ShilpaSutra CAD",
           },
           body: JSON.stringify({
-            model: imageBase64 ? "anthropic/claude-sonnet-4-5" : "anthropic/claude-sonnet-4",
+            model: "anthropic/claude-sonnet-4-6",
             messages: apiMessages,
             max_tokens: modeConfig.max_tokens,
             temperature: modeConfig.temperature,

--- a/src/app/api/generate-cad/route.ts
+++ b/src/app/api/generate-cad/route.ts
@@ -752,7 +752,7 @@ export async function POST(request: NextRequest) {
       try {
         const client = new Anthropic({ apiKey: anthropicKey });
         const claudeResponse = await client.messages.create({
-          model: "claude-sonnet-4-20250514",
+          model: "claude-sonnet-4-6",
           max_tokens: 1500,
           temperature: 0,
           system: `You are a CAD geometry parameter generator. Given a text description of a 3D part, return ONLY a JSON object with these fields:


### PR DESCRIPTION
## Wednesday Enhancement Pass — 2026-06-17

### What

Two-line model ID update across both AI API routes. No logic change.

| File | Old | New |
|------|-----|-----|
| `src/app/api/generate-cad/route.ts` (Anthropic SDK) | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
| `src/app/api/ai/generate/route.ts` (OpenRouter) | `anthropic/claude-sonnet-4-5` (image) / `anthropic/claude-sonnet-4` (text) | `anthropic/claude-sonnet-4-6` |

### Why

- `claude-sonnet-4-20250514` is a dated snapshot alias. `claude-sonnet-4-6` is the current stable release per Anthropic (August 2025 knowledge cutoff).
- The OpenRouter route had a conditional: vision requests used `claude-sonnet-4-5`, text used `claude-sonnet-4`. Both are superseded. `claude-sonnet-4-6` supports vision so the conditional is no longer needed.

### Not in this PR (covered by other open drafts)

Dead file removals (drawing-engine.ts, AIChatAssistant.tsx, AIToolPanel.tsx, etc.) are already in PRs #224, #226, #228. This PR is scoped to model IDs only so it can merge cleanly without conflict.

### ⚠️ Please merge at least one PR

No changes have landed on `main` since 2026-03-31. **30+ draft PRs are open.** Vercel production has zero successful deploys. See issue #229 for the triage plan. This PR is the smallest possible change — 2 lines — and is conflict-free.

## Audit findings filed as issues (not pushed — risky)

| Issue | Finding |
|-------|---------|
| New (this session) | `BOMEntry` interface defined independently in 4 files with incompatible shapes — consolidate into `src/types/cad.ts` |
| New (this session) | `AssemblyPart` interface defined independently in 3 files with incompatible shapes — consolidate into `src/types/cad.ts` |
| #210 | `vec3` math helpers duplicated across `constraint-store.ts` / `assembly-engine.ts` / `mate-solver.ts` |

## Vercel status

All 20 most recent deployments: `CANCELED` (feature-branch previews). Production (`main`) has not deployed since March 2026. Merging this PR will trigger a new production build.

## Test plan

- [ ] `npm run build` passes — TypeScript only, no logic change
- [ ] Text-to-CAD prompt in designer returns a valid response (exercises `/api/generate-cad`)
- [ ] AI chat response works (exercises `/api/ai/generate`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HT4oBV7WpD9AKCWvzqABiH)_