### PR TITLE
enhance(wed): centralise model IDs in src/lib/models.ts + fix invalid settings values

### DIFF
--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -6,6 +6,7 @@ import {
   type BOMEntry,
   type AssemblyPart,
 } from "@/lib/ai-reasoning-engine";
+import { MODELS } from "@/lib/models";
 
 // ─── Type Definitions ────────────────────────────────────────────────
 
@@ -746,7 +747,7 @@ export async function POST(request: NextRequest) {
             "X-Title": "ShilpaSutra CAD",
           },
           body: JSON.stringify({
-            model: imageBase64 ? "anthropic/claude-sonnet-4-5" : "anthropic/claude-sonnet-4",
+            model: imageBase64 ? MODELS.OR_CLAUDE_SONNET_VISION : MODELS.OR_CLAUDE_SONNET,
             messages: apiMessages,
             max_tokens: modeConfig.max_tokens,
             temperature: modeConfig.temperature,

--- a/src/app/api/generate-cad/route.ts
+++ b/src/app/api/generate-cad/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
+import { MODELS } from "@/lib/models";
 
 interface GenerateCADRequest {
   prompt: string;
@@ -752,7 +753,7 @@ export async function POST(request: NextRequest) {
       try {
         const client = new Anthropic({ apiKey: anthropicKey });
         const claudeResponse = await client.messages.create({
-          model: "claude-sonnet-4-20250514",
+          model: MODELS.CLAUDE_SONNET,
           max_tokens: 1500,
           temperature: 0,
           system: `You are a CAD geometry parameter generator. Given a text description of a 3D part, return ONLY a JSON object with these fields:

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -220,8 +220,8 @@ export default function SettingsPage() {
                   value={settings.aiModel}
                   onChange={(v) => settings.update({ aiModel: v })}
                   options={[
-                    { value: "claude-sonnet", label: "Claude Sonnet" },
-                    { value: "claude-opus", label: "Claude Opus" },
+                    { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+                    { value: "claude-opus-4-8", label: "Claude Opus 4.8" },
                     { value: "gpt-4o", label: "GPT-4o" },
                     { value: "gemini-pro", label: "Gemini Pro" },
                   ]}

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -1,0 +1,14 @@
+// Canonical Claude model IDs for all ShilpaSutra API routes and settings.
+// Update the constants here; every consumer picks up the change automatically.
+
+export const MODELS = {
+  // Anthropic SDK (direct API — used by /api/generate-cad)
+  CLAUDE_SONNET: "claude-sonnet-4-6",
+  CLAUDE_OPUS: "claude-opus-4-8",
+
+  // OpenRouter format (used by /api/ai/generate)
+  OR_CLAUDE_SONNET: "anthropic/claude-sonnet-4-6",
+  OR_CLAUDE_SONNET_VISION: "anthropic/claude-sonnet-4-5",
+} as const;
+
+export type ModelId = (typeof MODELS)[keyof typeof MODELS];

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,6 +1,7 @@
 "use client";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { MODELS } from "@/lib/models";
 
 export interface SettingsState {
   // General
@@ -50,7 +51,7 @@ const defaultSettings = {
   showGrid: true,
   showAxes: true,
   perspectiveMode: "perspective",
-  aiModel: "claude-sonnet",
+  aiModel: MODELS.CLAUDE_SONNET,
   apiKeyAnthropic: "",
   apiKeyOpenAI: "",
   apiKeyGoogle: "",


### PR DESCRIPTION
## Summary

Wednesday enhancement pass — create a single source of truth for Claude model IDs.

**Problem:** Claude model strings were hardcoded in three separate places using three different formats and stale version strings. Every model bump requires a multi-file grep-and-replace, which is why the same fix recurs in every weekly PR cycle without landing.

**Changes:**

- **New:** `src/lib/models.ts` — exports `MODELS` const with four canonical IDs:
  - `MODELS.CLAUDE_SONNET` → `"claude-sonnet-4-6"` (Anthropic SDK)
  - `MODELS.CLAUDE_OPUS` → `"claude-opus-4-8"` (Anthropic SDK)
  - `MODELS.OR_CLAUDE_SONNET` → `"anthropic/claude-sonnet-4-6"` (OpenRouter)
  - `MODELS.OR_CLAUDE_SONNET_VISION` → `"anthropic/claude-sonnet-4-5"` (OpenRouter vision)

- **`/api/generate-cad/route.ts`** — replaces hardcoded `"claude-sonnet-4-20250514"` with `MODELS.CLAUDE_SONNET`

- **`/api/ai/generate/route.ts`** — replaces hardcoded OpenRouter strings with `MODELS.OR_CLAUDE_SONNET` / `MODELS.OR_CLAUDE_SONNET_VISION`

- **`src/stores/settings-store.ts`** — default `aiModel` was `"claude-sonnet"` (not a valid API ID); now `MODELS.CLAUDE_SONNET`

- **`src/app/settings/page.tsx`** — model select options showed `"claude-sonnet"` / `"claude-opus"` (IDs no API accepts); updated to `"claude-sonnet-4-6"` / `"claude-opus-4-8"` with versioned labels

## Why this is different from open model-bump PRs (#230, #198, #177…)

Those PRs edit model strings in the API routes directly. This PR creates the constants file so **future bumps need only one edit** — superseding the recurring churn pattern.

## Test plan
- [ ] `/api/generate-cad` responds to a prompt (ANTHROPIC_API_KEY in env)
- [ ] `/api/ai/generate` routes text through `OR_CLAUDE_SONNET` and image through `OR_CLAUDE_SONNET_VISION`
- [ ] Settings → AI → Default Model shows "Claude Sonnet 4.6" and "Claude Opus 4.8"
- [ ] TypeScript build passes (`next build` or `tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuqCsmk9LD2Vq727jNK8h6

---
_Generated by [Claude Code](https://claude.ai/code/session_01AuqCsmk9LD2Vq727jNK8h6)_