### PR TITLE
security(sat): add HTTP security response headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,40 @@
 /** @type {import('next').NextConfig} */
+
+// HTTP security headers applied to every route.
+// CSP is intentionally broad (unsafe-eval + unsafe-inline) because Three.js /
+// WebGL shader compilation requires them; tighten per-route once the CAD
+// kernel is stable enough to enumerate trusted sources precisely.
+const securityHeaders = [
+  { key: "X-DNS-Prefetch-Control", value: "on" },
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      // Three.js shaders require eval; tighten once WASM CAD kernel is stable
+      "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
+      "style-src 'self' 'unsafe-inline'",
+      // WebGL textures and WASM blobs come from self + blob:
+      "img-src 'self' data: blob:",
+      "font-src 'self'",
+      // Connects to Anthropic, OpenRouter, and Railway DB proxy
+      "connect-src 'self' https://api.anthropic.com https://openrouter.ai",
+      // WebGL worker threads
+      "worker-src 'self' blob:",
+    ].join("; "),
+  },
+];
+
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["three"],
@@ -7,6 +43,9 @@ const nextConfig = {
   webpack: (config) => {
     config.externals = [...(config.externals || []), { canvas: "canvas" }];
     return config;
+  },
+  async headers() {
+    return [{ source: "/(.*)", headers: securityHeaders }];
   },
 };
 


### PR DESCRIPTION
## Summary

Saturday security audit — weekly angle: **Security**.

Adds six HTTP security response headers to every route via `next.config.mjs`:

| Header | Value | Threat mitigated |
|--------|-------|------------------|
| `X-Frame-Options` | `SAMEORIGIN` | Clickjacking |
| `X-Content-Type-Options` | `nosniff` | MIME sniffing |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Referrer leakage |
| `Permissions-Policy` | camera/mic/geo/cohort off | Feature abuse |
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | Downgrade attacks |
| `Content-Security-Policy` | see below | XSS, data injection |

**CSP note:** `unsafe-eval` and `unsafe-inline` are retained in `script-src` because Three.js requires eval for WebGL shader compilation. A comment in the file documents this tradeoff and the tightening path. The `connect-src` allowlist names Anthropic and OpenRouter explicitly; everything else is blocked.

## What was NOT changed

No logic, no dependencies, no component code — purely additive config.

## Issues this relates to / does NOT duplicate

- #166 (localStorage plaintext API keys) — separate issue, risky refactor, not touched here
- #208 / #222 (API rate limiting + auth) — separate concern, not touched here
- #221 (SVG dangerouslySetInnerHTML sanitization) — separate concern, not touched here
- #223 (input size guards) — separate concern, not touched here

## Test plan

- [ ] `next build` passes (TypeScript + Next.js config parse)
- [ ] Load the app in a browser and inspect response headers via DevTools → Network → any request → Response Headers
- [ ] Verify `X-Frame-Options: SAMEORIGIN` is present
- [ ] Verify `Content-Security-Policy` is present and does not break 3D viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sv13H3W7yJaF82e8fKfPYX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sv13H3W7yJaF82e8fKfPYX)_