### PR TITLE
chore(tue/bulk): drop 4 dead packages + 3 unused export blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,17 +24,13 @@
     "clsx": "^2.1.1",
     "docx": "^9.6.1",
     "file-saver": "^2.0.5",
-    "framer-motion": "^11.11.11",
-    "html2canvas": "^1.4.1",
     "jspdf": "^4.2.1",
     "lucide-react": "^0.454.0",
     "next": "14.2.15",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-icons": "^5.3.0",
     "tailwind-merge": "^2.5.4",
     "three": "^0.169.0",
-    "three-bvh-csg": "^0.0.16",
     "zustand": "^5.0.1"
   },
   "devDependencies": {

--- a/src/lib/pvTestingTemplates.ts
+++ b/src/lib/pvTestingTemplates.ts
@@ -526,9 +526,6 @@ export const allPVTemplates: PVTemplate[] = [
   ...adaptIECTemplates(),
 ];
 
-/** All categories derived from allPVTemplates (preserves PV_TEMPLATE_CATEGORIES order) */
-export const ALL_PV_CATEGORIES: PVTemplateCategory[] = PV_TEMPLATE_CATEGORIES;
-
 // ─── W3-4: IEC 61215 / 61730 / 62788 Test Equipment Templates ────────────────
 // Re-exported from pvIECTestRegistry for unified template browser access.
 export {

--- a/src/lib/report-generator.ts
+++ b/src/lib/report-generator.ts
@@ -350,32 +350,3 @@ export function parseNLReportRequest(prompt: string): Partial<ReportConfig> {
   return { type, title: titleMap[type] };
 }
 
-/* ── Pre-built Compliance Data ── */
-export const IEC_61215_CHECKS: ComplianceCheck[] = [
-  { clause: "10.1", description: "Performance at STC", requirement: "Pmax ≥ rated × 0.98", actual: "Pmax = 99.5% rated", status: "pass" },
-  { clause: "10.2", description: "Performance at NOCT", requirement: "Efficiency ≥ 18%", actual: "η = 19.2%", status: "pass" },
-  { clause: "10.3", description: "Temperature coefficients", requirement: "Pmax TC ≤ -0.5%/°C", actual: "-0.38%/°C", status: "pass" },
-  { clause: "10.4", description: "Low irradiance performance", requirement: "Efficiency ≥ 95% of STC at 200 W/m²", actual: "96.1%", status: "pass" },
-  { clause: "10.9", description: "Hot-spot endurance", requirement: "No cell damage after test", actual: "No damage observed", status: "pass" },
-  { clause: "10.11", description: "UV preconditioning", requirement: "Pmax degradation ≤ 5%", actual: "2.1% degradation", status: "pass" },
-  { clause: "10.13", description: "Damp heat test", requirement: "Pmax degradation ≤ 5%", actual: "3.8% degradation", status: "pass" },
-  { clause: "10.18", description: "Mechanical load test", requirement: "No failure at 2400 Pa", actual: "Passed 2400 Pa", status: "pass" },
-];
-
-export const IS_800_CHECKS: ComplianceCheck[] = [
-  { clause: "6.1", description: "Tension members", requirement: "Td ≤ Ag × fy / γm0", actual: "Utilization: 0.72", status: "pass" },
-  { clause: "7.1", description: "Compression members", requirement: "Pd ≤ Ae × fcd", actual: "Utilization: 0.68", status: "pass" },
-  { clause: "8.1", description: "Flexural members", requirement: "Md ≤ Zpz × fy / γm0", actual: "Utilization: 0.81", status: "pass" },
-  { clause: "9.2", description: "Shear capacity", requirement: "Vd ≤ Av × fyw / (√3 × γm0)", actual: "Utilization: 0.45", status: "pass" },
-  { clause: "10.1", description: "Connection design", requirement: "Bolt shear capacity adequate", actual: "SF = 2.1", status: "pass" },
-  { clause: "5.6", description: "Deflection limits", requirement: "δ ≤ L/300", actual: "δ = L/420", status: "pass" },
-];
-
-export const ISO_2768_CHECKS: ComplianceCheck[] = [
-  { clause: "m-K", description: "Linear dimensions ≤100mm", requirement: "±0.1mm", actual: "Max deviation: 0.07mm", status: "pass" },
-  { clause: "m-K", description: "Linear dimensions 100–300mm", requirement: "±0.2mm", actual: "Max deviation: 0.14mm", status: "pass" },
-  { clause: "m-K", description: "Angular dimensions", requirement: "±0°30′", actual: "Max deviation: 0°22′", status: "pass" },
-  { clause: "m-K", description: "Flatness ≤100mm", requirement: "0.1mm", actual: "0.06mm", status: "pass" },
-  { clause: "m-K", description: "Roundness", requirement: "0.05mm", actual: "0.03mm", status: "pass" },
-  { clause: "m-K", description: "Straightness ≤100mm", requirement: "0.1mm", actual: "0.08mm", status: "pass" },
-];


### PR DESCRIPTION
## Tuesday bulk-removal pass — 2026-06-24

### What changed
All removals confirmed zero static **and** dynamic import references across the full `src/` tree (ripgrep audit run this session).

#### `package.json` — 4 unused runtime deps removed
| Package | Version | Evidence of non-use |
|---------|---------|---------------------|
| `framer-motion` | ^11.11.11 | No `import … from 'framer-motion'` in src/ |
| `html2canvas` | ^1.4.1 | Only in two code comments; never actually imported |
| `react-icons` | ^5.3.0 | No `import … from 'react-icons/…'` in src/ |
| `three-bvh-csg` | ^0.0.16 | No `import … from 'three-bvh-csg'` in src/ |

`file-saver` and `docx` were also audited and are **kept** — both used via dynamic `import()` in `src/app/drawings/page.tsx`.

#### `src/lib/report-generator.ts` — 3 placeholder compliance arrays removed
`IEC_61215_CHECKS`, `IS_800_CHECKS`, `ISO_2768_CHECKS` — hardcoded sample data, zero importers. The `generateReport` and `parseNLReportRequest` functions are retained (see issue #___ for full audit of that file).

#### `src/lib/pvTestingTemplates.ts` — 1 redundant alias removed
`ALL_PV_CATEGORIES` was an `export const … = PV_TEMPLATE_CATEGORIES` alias with no importers. `PV_TEMPLATE_CATEGORIES` itself is kept and used.

### Scope
- **−36 lines** of dead code
- **4 fewer npm packages** to install, audit, and update

### Risky cleanups filed as issues (not in this PR)
- Consolidate 4 duplicate `parseDimensions` functions
- Deduplicate `estimateFirstLayerHeight` across cfd-boundary / cfd-engine
- Unexport/remove dead exports in `structural-engine.ts`
- Full dead-code pass on `report-generator.ts` (`generateReport`, `parseNLReportRequest`)

### Vercel build status
All 20 recent Vercel deployments show `state: CANCELED` — all are feature-branch preview builds; **none have reached production**. The weekly cleanup PRs appear to be accumulating without being merged to `main`. Recommend a merge triage session.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Kzjp4ePBMDnWZWKyW8Tnfm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kzjp4ePBMDnWZWKyW8Tnfm)_