### PR TITLE
security(sat): strip error leaks, harden inputs, add HTTP headers, bump model

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,23 @@
 /** @type {import('next').NextConfig} */
+const SECURITY_HEADERS = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-XSS-Protection", value: "1; mode=block" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+];
+
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["three"],
   devIndicators: { appIsrStatus: false },
   turbopack: {},
+  async headers() {
+    return [{ source: "/(.*)", headers: SECURITY_HEADERS }];
+  },
   webpack: (config) => {
     config.externals = [...(config.externals || []), { canvas: "canvas" }];
     return config;

--- a/src/app/api/ai/generate/route.ts
+++ b/src/app/api/ai/generate/route.ts
@@ -669,6 +669,9 @@ function thinkingConfig(mode: "Normal" | "Extended" | "Deep" | undefined): {
   }
 }
 
+const MAX_PROMPT_CHARS = 8_000;
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB base64
+
 export async function POST(request: NextRequest) {
   try {
     const body: GenerateRequest = await request.json();
@@ -676,6 +679,14 @@ export async function POST(request: NextRequest) {
 
     if ((!prompt || prompt.trim().length === 0) && (!messages || messages.length === 0)) {
       return NextResponse.json({ error: "Prompt or messages array is required" }, { status: 400 });
+    }
+
+    if (prompt && prompt.length > MAX_PROMPT_CHARS) {
+      return NextResponse.json({ error: "Prompt exceeds 8 000 character limit" }, { status: 400 });
+    }
+
+    if (imageBase64 && imageBase64.length > MAX_IMAGE_BYTES) {
+      return NextResponse.json({ error: "Image payload exceeds 10 MB limit" }, { status: 400 });
     }
 
     const activePrompt = prompt || messages?.[messages.length - 1]?.content || "";
@@ -721,8 +732,10 @@ export async function POST(request: NextRequest) {
         ];
 
         if (messages && messages.length > 0) {
-          for (const msg of messages) {
-            if (msg.role !== "system") apiMessages.push(msg);
+          // Strip system messages (prevent prompt injection) and cap conversation depth
+          const userMessages = messages.filter((m) => m.role !== "system").slice(-20);
+          for (const msg of userMessages) {
+            apiMessages.push(msg);
           }
         } else if (imageBase64) {
           // Multimodal: send image + text
@@ -802,9 +815,7 @@ export async function POST(request: NextRequest) {
       fallback: !apiKey,
     } as GenerateResponse);
   } catch (error) {
-    return NextResponse.json(
-      { error: "Failed to generate", details: String(error) },
-      { status: 500 }
-    );
+    console.error("[api/ai/generate]", error);
+    return NextResponse.json({ error: "Failed to generate" }, { status: 500 });
   }
 }

--- a/src/app/api/generate-cad/route.ts
+++ b/src/app/api/generate-cad/route.ts
@@ -752,7 +752,7 @@ export async function POST(request: NextRequest) {
       try {
         const client = new Anthropic({ apiKey: anthropicKey });
         const claudeResponse = await client.messages.create({
-          model: "claude-sonnet-4-20250514",
+          model: "claude-sonnet-4-6",
           max_tokens: 1500,
           temperature: 0,
           system: `You are a CAD geometry parameter generator. Given a text description of a 3D part, return ONLY a JSON object with these fields:
@@ -827,9 +827,7 @@ All dimensions in mm. Return ONLY valid JSON, no markdown.`,
       },
     });
   } catch (error) {
-    return NextResponse.json(
-      { error: "Failed to generate CAD model", details: String(error) },
-      { status: 500 }
-    );
+    console.error("[api/generate-cad]", error);
+    return NextResponse.json({ error: "Failed to generate CAD model" }, { status: 500 });
   }
 }

--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -226,6 +226,11 @@ export async function POST(request: NextRequest) {
     const body: SimulationRequest = await request.json();
     const { analysisType, meshElements, material, solverConfig, cfdConfig, geometry } = body;
 
+    const ALLOWED_ANALYSIS_TYPES = ["structural", "thermal", "cfd", "modal", "fatigue"];
+    if (!ALLOWED_ANALYSIS_TYPES.includes(analysisType)) {
+      return NextResponse.json({ error: "Invalid analysisType" }, { status: 400 });
+    }
+
     const nx = Math.max(10, Math.min(100, Math.round(Math.sqrt(meshElements))));
     const ny = nx;
     const width = geometry?.width || 100;
@@ -233,13 +238,15 @@ export async function POST(request: NextRequest) {
     const E = parseFloat(material.E) || 205e9;
     const nu = parseFloat(material.v) || 0.29;
     const k = parseFloat(material.k) || 50;
+    const safeMaxIter = Math.max(1, Math.min(500, solverConfig.maxIterations));
+    const safeTolerance = Math.max(1e-10, Math.min(1, solverConfig.tolerance));
     const startTime = Date.now();
 
     let results: Record<string, unknown>;
 
     switch (analysisType) {
       case "thermal": {
-        const thermal = solveThermal2D(nx, ny, k, 400, 300, 350, 320, solverConfig.maxIterations, solverConfig.tolerance);
+        const thermal = solveThermal2D(nx, ny, k, 400, 300, 350, 320, safeMaxIter, safeTolerance);
         const tMin = Math.min(...thermal.field);
         const tMax = Math.max(...thermal.field);
         const tAvg = thermal.field.reduce((s, v) => s + v, 0) / thermal.field.length;
@@ -273,7 +280,7 @@ export async function POST(request: NextRequest) {
         const inletV = cfdConfig?.inletVelocity || 10;
         const rho = parseFloat(material.rho) || 1.225;
         const mu = 1.81e-5;
-        const cfd = solveCFD2D(nx, ny, inletV, rho, mu, solverConfig.maxIterations);
+        const cfd = solveCFD2D(nx, ny, inletV, rho, mu, safeMaxIter);
 
         results = {
           velocity: { max: Math.round(cfd.maxVel * 100) / 100, min: 0, avg: Math.round(cfd.maxVel * 0.67 * 100) / 100, unit: "m/s" },
@@ -336,9 +343,7 @@ export async function POST(request: NextRequest) {
       engine: analysisType === "cfd" ? "ShilpaSutra CFD v2.0" : "ShilpaSutra FEA v2.0",
     });
   } catch (error) {
-    return NextResponse.json(
-      { error: "Simulation failed", details: String(error) },
-      { status: 500 }
-    );
+    console.error("[api/simulate]", error);
+    return NextResponse.json({ error: "Simulation failed" }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary

Saturday security pass. Six targeted hardening changes, all on files that are currently unprotected in `main`. Every prior Saturday PR covering these issues is still open as a draft — this is the first from the **new session branch** `claude/determined-volta-ymejaj`.

### Changes

| # | File | Change |
|---|---|---|
| 1 | All 3 API routes | Strip `details: String(error)` from 500 responses; log server-side only |
| 2 | `/api/ai/generate` | Reject prompts >8 000 chars and imageBase64 >10 MB (HTTP 400) |
| 3 | `/api/ai/generate` | Filter `role:"system"` from forwarded `messages[]`; cap depth at 20 |
| 4 | `/api/simulate` | Whitelist `analysisType`; clamp `maxIterations` to [1, 500] and `tolerance` to [1e-10, 1] |
| 5 | `/api/generate-cad` | Bump `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (deprecated ID) |
| 6 | `next.config.mjs` | Add `X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy` headers |

### Why these changes

- **Error detail leak** (MEDIUM): `String(error)` in 500 responses exposes internal paths, SDK error bodies, and stack fragments to callers.
- **Cost-cap DoS** (MEDIUM): Uncapped prompt/image sizes allow a caller to inflate OpenRouter token spend with no server-side resistance.
- **Prompt injection** (MEDIUM): Forwarding caller-supplied `role:"system"` messages lets any client overwrite the system prompt.
- **CPU DoS** (LOW): `maxIterations` on the thermal Gauss-Seidel solver was unbounded; a large value causes extended server CPU burn.
- **Stale model ID** (LOW): `claude-sonnet-4-20250514` is deprecated; the API will eventually reject it with no fallback.
- **Missing browser headers** (MEDIUM): No `X-Frame-Options` or `X-Content-Type-Options` means the app can be framed and MIME-sniffed.

### Deferred to issues (too large for one PR)

- **Critical**: Next.js 14.2.15 has CVE GHSA-f82v-jwr5-mffw (auth bypass in middleware) — upgrade to 16.x needed
- **High**: `@anthropic-ai/sdk` ~0.80 has GHSA-5474-4w2j-mq4c (sandbox escape) — upgrade to ≥0.106.0
- **High**: All 3 API routes have no authentication — any unauthenticated caller can drain API credits
- **High**: No rate limiting on cost-incurring routes (`/api/ai/generate`, `/api/generate-cad`)
- **High**: API keys stored in plaintext in Zustand `persist` (localStorage) — `shilpasutra-settings` key
- **Medium**: SVG attribute values in `drawingEngine.ts` are not XML-escaped before `dangerouslySetInnerHTML`

### PR backlog alert

**30 draft PRs are open and none have been merged to main.** The same security issues have been identified and proposed in PRs #158, #187, #207, #220, #239 and many others since 2026-05-05. None landed. Until at least one batch is merged into `main`, these issues will continue to reappear in every weekly audit — and more critically, the production app remains unprotected.

### Vercel status

All 20 tracked Vercel deployments for this project show `state: CANCELED` with `target: null`. **There is no current production deployment.** The last production build appears predates the Claude automation sessions. The Vercel project may need its branch trigger reconfigured to build from `main` on merge.

## Test plan

- [ ] Verify `POST /api/ai/generate` with `prompt` > 8 000 chars returns HTTP 400
- [ ] Verify `POST /api/ai/generate` with `messages` containing `role:"system"` does not forward that message to OpenRouter
- [ ] Verify `POST /api/simulate` with unknown `analysisType` returns HTTP 400
- [ ] Verify `POST /api/simulate` with `maxIterations: 999999` resolves without hanging
- [ ] Verify response headers include `X-Frame-Options: DENY` on any page
- [ ] Verify 500 responses no longer include a `details` field
- [ ] Verify `claude-sonnet-4-6` model ID is accepted by the Anthropic API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX1RJSabn4HXJB9sMmMafB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JX1RJSabn4HXJB9sMmMafB)_