### PR TITLE
test(thu): add unit tests for materials.ts and pvIECTestRegistry.ts

### DIFF
--- a/src/lib/__tests__/materials.test.ts
+++ b/src/lib/__tests__/materials.test.ts
@@ -1,0 +1,117 @@
+import {
+  materials,
+  getMaterialByName,
+  getMaterialsByCategory,
+  getMaterialCategories,
+  compareMaterials,
+  calculateWeight,
+  getMaterialColor,
+} from "../materials";
+
+describe("materials data", () => {
+  it("contains at least one material with required fields", () => {
+    expect(materials.length).toBeGreaterThan(0);
+    for (const m of materials) {
+      expect(m.name).toBeTruthy();
+      expect(m.density).toBeGreaterThan(0);
+      expect(m.color).toMatch(/^#[0-9a-fA-F]{3,8}$/);
+    }
+  });
+
+  it("has no duplicate material names", () => {
+    const names = materials.map((m) => m.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+describe("getMaterialByName", () => {
+  it("finds a material by exact name", () => {
+    const mat = getMaterialByName("Steel 1045");
+    expect(mat).toBeDefined();
+    expect(mat?.name).toBe("Steel 1045");
+  });
+
+  it("finds a material by case-insensitive partial match", () => {
+    const mat = getMaterialByName("aluminum 6061");
+    expect(mat?.name).toBe("Aluminum 6061-T6");
+  });
+
+  it("returns undefined for an unknown material", () => {
+    expect(getMaterialByName("Unobtainium")).toBeUndefined();
+  });
+});
+
+describe("getMaterialsByCategory", () => {
+  it("returns only materials in the requested category", () => {
+    const steelMats = getMaterialsByCategory("Steel");
+    expect(steelMats.length).toBeGreaterThan(0);
+    for (const m of steelMats) {
+      expect(m.category).toBe("Steel");
+    }
+  });
+
+  it("is case-insensitive", () => {
+    expect(getMaterialsByCategory("steel").length).toBe(
+      getMaterialsByCategory("Steel").length
+    );
+  });
+
+  it("returns empty array for unknown category", () => {
+    expect(getMaterialsByCategory("Unobtainium")).toEqual([]);
+  });
+});
+
+describe("getMaterialCategories", () => {
+  it("returns a sorted list of unique categories", () => {
+    const categories = getMaterialCategories();
+    const sorted = [...categories].sort();
+    expect(categories).toEqual(sorted);
+    expect(new Set(categories).size).toBe(categories.length);
+    expect(categories).toContain("Steel");
+  });
+});
+
+describe("compareMaterials", () => {
+  it("returns null when either material is unknown", () => {
+    expect(compareMaterials("Steel 1045", "Unobtainium")).toBeNull();
+    expect(compareMaterials("Unobtainium", "Steel 1045")).toBeNull();
+  });
+
+  it("compares two known materials", () => {
+    const cmp = compareMaterials("Steel 1045", "Aluminum 6061-T6");
+    expect(cmp).not.toBeNull();
+    expect(cmp?.materialA.name).toBe("Steel 1045");
+    expect(cmp?.materialB.name).toBe("Aluminum 6061-T6");
+    expect(cmp?.differences.density.a).toBe(cmp?.materialA.density);
+    expect(cmp?.differences.density.b).toBe(cmp?.materialB.density);
+    expect(cmp?.differences.density.ratio).toBeCloseTo(
+      (cmp?.materialA.density as number) / (cmp?.materialB.density as number)
+    );
+  });
+});
+
+describe("calculateWeight", () => {
+  it("computes weight in kg from volume in mm3", () => {
+    // Steel 1045 density = 7850 kg/m3; 1e9 mm3 = 1 m3
+    const weight = calculateWeight("Steel 1045", 1e9);
+    expect(weight).toBeCloseTo(7850);
+  });
+
+  it("returns null for unknown material", () => {
+    expect(calculateWeight("Unobtainium", 1000)).toBeNull();
+  });
+
+  it("returns 0 for zero volume", () => {
+    expect(calculateWeight("Steel 1045", 0)).toBe(0);
+  });
+});
+
+describe("getMaterialColor", () => {
+  it("returns the hex color for a known material", () => {
+    expect(getMaterialColor("Steel 1045")).toBe("#8a8a8a");
+  });
+
+  it("returns null for unknown material", () => {
+    expect(getMaterialColor("Unobtainium")).toBeNull();
+  });
+});

--- a/src/lib/__tests__/pvIECTestRegistry.test.ts
+++ b/src/lib/__tests__/pvIECTestRegistry.test.ts
@@ -1,0 +1,77 @@
+import {
+  PV_IEC_ALL_TEMPLATES,
+  PV_IEC_TEMPLATES_PART1,
+  IEC_CATEGORY_LABELS,
+  IEC_STANDARDS_REFERENCE,
+  IEC_TEMPLATE_BROWSER_ENTRIES,
+  getIECTemplateById,
+  getIECTemplatesByCategory,
+} from "../pvIECTestRegistry";
+
+describe("PV_IEC_ALL_TEMPLATES", () => {
+  it("combines part 1 and part 2 templates", () => {
+    expect(PV_IEC_ALL_TEMPLATES.length).toBeGreaterThan(
+      PV_IEC_TEMPLATES_PART1.length
+    );
+  });
+
+  it("has unique template ids", () => {
+    const ids = PV_IEC_ALL_TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("only uses categories present in IEC_CATEGORY_LABELS", () => {
+    for (const t of PV_IEC_ALL_TEMPLATES) {
+      expect(Object.keys(IEC_CATEGORY_LABELS)).toContain(t.category);
+    }
+  });
+});
+
+describe("getIECTemplateById", () => {
+  it("finds an existing template", () => {
+    const first = PV_IEC_ALL_TEMPLATES[0];
+    expect(getIECTemplateById(first.id)).toEqual(first);
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(getIECTemplateById("does-not-exist")).toBeUndefined();
+  });
+});
+
+describe("getIECTemplatesByCategory", () => {
+  it("returns only templates matching the category", () => {
+    const category = PV_IEC_ALL_TEMPLATES[0].category;
+    const filtered = getIECTemplatesByCategory(category);
+    expect(filtered.length).toBeGreaterThan(0);
+    for (const t of filtered) {
+      expect(t.category).toBe(category);
+    }
+  });
+
+  it("returns empty array for unknown category", () => {
+    expect(getIECTemplatesByCategory("not-a-category")).toEqual([]);
+  });
+});
+
+describe("IEC_TEMPLATE_BROWSER_ENTRIES", () => {
+  it("has one browser entry per template with a resolved category label", () => {
+    expect(IEC_TEMPLATE_BROWSER_ENTRIES.length).toBe(
+      PV_IEC_ALL_TEMPLATES.length
+    );
+    for (const entry of IEC_TEMPLATE_BROWSER_ENTRIES) {
+      expect(entry.categoryLabel).toBe(IEC_CATEGORY_LABELS[entry.category]);
+      expect(entry.fieldCount).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("IEC_STANDARDS_REFERENCE", () => {
+  it("maps every entry to a non-empty description", () => {
+    for (const [standard, description] of Object.entries(
+      IEC_STANDARDS_REFERENCE
+    )) {
+      expect(standard.length).toBeGreaterThan(0);
+      expect(description.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Weekly audit angle: **Thursday = tests**.

Adds two new unit test suites (25 new assertions, 62 total passing) for previously-untested pure utility modules:

- `src/lib/__tests__/materials.test.ts` — `getMaterialByName`, `getMaterialsByCategory`, `getMaterialCategories`, `compareMaterials`, `calculateWeight`, `getMaterialColor`
- `src/lib/__tests__/pvIECTestRegistry.test.ts` — `getIECTemplateById`, `getIECTemplatesByCategory`, `PV_IEC_ALL_TEMPLATES` combination integrity, `IEC_TEMPLATE_BROWSER_ENTRIES`, `IEC_STANDARDS_REFERENCE`

**No deletions or dependency changes in this PR.**

## Why no dead-code removal this run

This repo currently has **63 open draft PRs**, the large majority proposing the same dead-code deletions (`drawing-engine.ts`, `cadCommandHandler.ts`, `assembly-engine.ts`, `cfd-piso.ts`, `csg-engine.ts`, `fea-engine.ts`, etc.), because none of the prior cleanup PRs have been merged into `main`. This has already been flagged repeatedly and escalated with no action taken:

- #178 — "10+ unmerged cleanup PRs — triage and merge or close stale ones" (2026-05-27)
- #191 — "triage 30 stacked draft PRs" (2026-05-31)
- #200 — "merge or close the 30+ stale dead-code draft PRs" (2026-06-03)
- #212 — Sunday roadmap pass flagging 30+ PRs / 104+ issues as the #1 blocker (2026-06-07)

Six+ weeks later the backlog has grown to 63 PRs and none of those recommendations have been acted on. Opening yet another PR proposing the same deletions would just add PR #64 to the pile and guarantee more merge conflicts. This PR instead only touches two brand-new test files with no overlap with any open PR or shared file, so it can be merged independently of the cleanup backlog.

## Also verified this run (no action needed / already tracked)

- **Vercel (`shilpa-sutra` project)**: latest production deployment is `READY`, target `production`, matches current `main` HEAD (`b433de4`). Production is green.
- **`npm audit`**: 12 vulnerabilities (1 critical — `next@14.2.15`, fix requires a breaking major-version bump to Next 16). Not yet tracked in a dedicated issue; recommend filing/prioritizing separately since it's a critical severity finding, unlike the routine dead-code churn.
- Dead-code / duplicate-file / unused-dependency findings from this session's audit match what's already documented in #101, #178, #191, #200, #212 — not re-filed to avoid further duplication.

## Test plan

- [x] `npx jest --config jest.config.ts` — 3 suites, 62 tests, all passing
- [x] `npx tsc --noEmit` — no type errors
- [x] New files only; zero changes to any file touched by another open PR

https://claude.ai/code/session_01JM19Wc4Ppqv9Vr2XsUsG4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01JM19Wc4Ppqv9Vr2XsUsG4F)_